### PR TITLE
ngx-pagespeed Dockerfile for alpine 3.4 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,119 @@
+FROM alpine:3.4
+
+# Inspired by wernight/docker-alpine-nginx-pagespeed
+
+RUN apk --no-cache add \
+        ca-certificates \
+        libuuid \
+        apr \
+        apr-util \
+        libjpeg-turbo \
+        icu \
+        icu-libs \
+        openssl \
+        pcre \
+        zlib
+
+RUN set -x && \
+    apk --no-cache add -t .build-deps \
+        apache2-dev \
+        apr-dev \
+        apr-util-dev \
+        build-base \
+        curl \
+        icu-dev \
+        libjpeg-turbo-dev \
+        linux-headers \
+        gperf \
+        openssl-dev \
+        pcre-dev \
+        python \
+        zlib-dev && \
+    # Build libpng:
+    # This sadly requires an old version of http://www.libpng.org/pub/png/libpng.html
+    LIBPNG_VERSION=1.2.56 && \
+    cd /tmp && \
+    curl -L http://prdownloads.sourceforge.net/libpng/libpng-${LIBPNG_VERSION}.tar.gz | tar -zx && \
+    cd /tmp/libpng-${LIBPNG_VERSION} && \
+    ./configure --build=$CBUILD --host=$CHOST --prefix=/usr --enable-shared --with-libpng-compat && \
+    make install V=0 && \
+    # Build PageSpeed:
+    # Check https://github.com/pagespeed/ngx_pagespeed/releases for the latest version
+    PAGESPEED_VERSION=1.12.34.3 && \
+    NGX_PAGESPEED_VERSION=1.12.34.3 && \
+    cd /tmp && \
+    curl -L https://github.com/ashishk-1/ngx-pagespeed-alpine/blob/ashishk-ngx-pagespeed-alpine34/mod-pagespeed-beta-1.12.34.3.tar.bz2?raw=true | tar -jx && \
+    curl -L https://github.com/pagespeed/ngx_pagespeed/archive/v${NGX_PAGESPEED_VERSION}-stable.tar.gz | tar -zx && \
+    cd /tmp/modpagespeed-${PAGESPEED_VERSION} && \
+    curl -L https://raw.githubusercontent.com/ashishk-1/ngx-pagespeed-alpine/ashishk-ngx-pagespeed-alpine34/patches/automatic_makefile.patch | patch -p1 && \
+    curl -L https://raw.githubusercontent.com/ashishk-1/ngx-pagespeed-alpine/ashishk-ngx-pagespeed-alpine34/patches/libpng_cflags.patch | patch -p1 && \
+    curl -L https://raw.githubusercontent.com/ashishk-1/ngx-pagespeed-alpine/ashishk-ngx-pagespeed-alpine34/patches/pthread_nonrecursive_np.patch | patch -p1 && \
+    curl -L https://raw.githubusercontent.com/ashishk-1/ngx-pagespeed-alpine/ashishk-ngx-pagespeed-alpine34/patches/rename_c_symbols.patch | patch -p1 && \
+    curl -L https://raw.githubusercontent.com/ashishk-1/ngx-pagespeed-alpine/ashishk-ngx-pagespeed-alpine34/patches/stack_trace_posix.patch | patch -p1 && \
+    ./generate.sh -D use_system_libs=1 -D _GLIBCXX_USE_CXX11_ABI=0 -D use_system_icu=1 && \
+    cd /tmp/modpagespeed-${PAGESPEED_VERSION}/src && \
+    make BUILDTYPE=Release CXXFLAGS=" -I/usr/include/apr-1 -I/tmp/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" CFLAGS=" -I/usr/include/apr-1 -I/tmp/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" -j4 && \
+    cd /tmp/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed/automatic/ && \
+    make psol BUILDTYPE=Release CXXFLAGS=" -I/usr/include/apr-1 -I/tmp/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" CFLAGS=" -I/usr/include/apr-1 -I/tmp/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" && \
+    mkdir -p /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol && \
+    mkdir -p /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/lib/Release/linux/x64 && \
+    mkdir -p /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/out/Release && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/out/Release/obj /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/out/Release/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/net /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/testing /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/third_party /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/tools /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed/automatic/pagespeed_automatic.a /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/lib/Release/linux/x64 && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/url /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/ && \
+    # Build Nginx with support for PageSpeed:
+    # Check http://nginx.org/en/download.html for the latest version.
+    NGINX_VERSION=1.12.1 && \
+    cd /tmp && \
+    curl -L http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar -zx && \
+    cd /tmp/nginx-${NGINX_VERSION} && \
+    LD_LIBRARY_PATH=/tmp/modpagespeed-${PAGESPEED_VERSION}/usr/lib ./configure --with-ipv6 \
+        --prefix=/var/lib/nginx \
+        --sbin-path=/usr/sbin \
+        --modules-path=/usr/lib/nginx \
+        --with-http_ssl_module \
+        --with-http_gzip_static_module \
+        --with-file-aio \
+        --with-http_v2_module \
+        --without-http_autoindex_module \
+        --without-http_browser_module \
+        --without-http_geo_module \
+        --without-http_map_module \
+        --without-http_memcached_module \
+        --without-http_userid_module \
+        --without-mail_pop3_module \
+        --without-mail_imap_module \
+        --without-mail_smtp_module \
+        --without-http_split_clients_module \
+        --without-http_scgi_module \
+        --without-http_referer_module \
+        --without-http_upstream_ip_hash_module \
+        --prefix=/etc/nginx \
+        --conf-path=/etc/nginx/nginx.conf \
+        --http-log-path=/var/log/nginx/access.log \
+        --error-log-path=/var/log/nginx/error.log \
+        --pid-path=/var/run/nginx.pid \
+        --add-module=/tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable \
+        --with-cc-opt="-fPIC -I /usr/include/apr-1" \
+        --with-ld-opt="-luuid -lapr-1 -laprutil-1 -licudata -licuuc -L/tmp/modpagespeed-${PAGESPEED_VERSION}/usr/lib -lpng12 -lturbojpeg -ljpeg" && \
+    make install --silent && \
+    # Clean-up:
+    cd && \
+    apk del .build-deps && \
+    rm -rf /tmp/* && \
+    # forward request and error logs to docker log collector
+    ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log && \
+    # Make PageSpeed cache writabl:
+    mkdir -p /var/cache/ngx_pagespeed && \
+    chmod -R o+wr /var/cache/ngx_pagespeed
+
+EXPOSE 80 443
+
+CMD ["nginx", "-g", "daemon off;"]
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # ngx-pagespeed-alpine
-ngx_pagespeed docker image for Alpine
+ngx_pagespeed Dockerfile for Alpine, based on wernight/docker-alpine-nginx-pagespeed
+
+## Docker base
+This image is based on Alpine Linux version 3.4
+
+## Pagespeed Components:
+### mod-pagespeed
+Custom built beta release tarball of mod-pagespeed (mod-pagespeed-beta-1.12.34.3.tar.bz2 uploaded in this repo). This custom tarball includes the upgraded GRPC version(1.4.5) which is required for the Alpine build.
+### ngx-pagespeed
+Stable ngx-pagespeed version 1.12.34.3 fetched from [ngx pagespeed archive](https://github.com/pagespeed/ngx_pagespeed/archive/v1.12.34.3-stable.tar.gz).
+### Nginx
+Stable NGINX version 1.12.1 fetched from [nginx.org](http://nginx.org/download/nginx-1.12.1.tar.gz) .
+
+## Using the Dockerfile
+### Use docker build command to build an image from dockerfile:
+      $ docker build -t <image_tag> -f <dockerfile_path> .
+  Refer [this](https://docs.docker.com/engine/reference/commandline/build/) for additional options.
+
+### Run this container as an independent service:
+    $ docker run -d -p 80:80 <image_tag>
+  Refer [this](https://docs.docker.com/engine/reference/run/) for additional options.
+
+## TODO
+- Update the Dockerfile to use the official mod-pagespeed release tarball once it is available and published.
+- Support Alpine Linux version 3.6

--- a/patches/automatic_makefile.patch
+++ b/patches/automatic_makefile.patch
@@ -1,0 +1,30 @@
+--- a/src/pagespeed/automatic/Makefile
++++ b/src/pagespeed/automatic/Makefile
+@@ -145,8 +145,6 @@
+   pagespeed/libpagespeed_thread.a \
+   pagespeed/libpthread_system.a \
+   pagespeed/libutil.a \
+-  third_party/apr/libapr.a \
+-  third_party/aprutil/libaprutil.a \
+   third_party/base64/libbase64.a \
+   third_party/chromium/src/base/third_party/dynamic_annotations/libdynamic_annotations.a \
+   third_party/css_parser/libcss_parser.a \
+@@ -162,18 +160,11 @@
+   third_party/grpc/libgrpc_core.a \
+   third_party/grpc/libgrpc_cpp.a \
+   third_party/hiredis/libhiredis.a \
+-  third_party/icu/libicudata.a \
+-  third_party/icu/libicuuc.a \
+   third_party/jsoncpp/libjsoncpp.a \
+-  third_party/libjpeg_turbo/libjpeg.a \
+-  third_party/libjpeg_turbo/src/libjpeg_turbo.a \
+-  third_party/libpng/libpng.a \
+   third_party/optipng/libopngreduc.a \
+   third_party/protobuf/libprotobuf_full_do_not_use.a \
+   third_party/re2/libre2.a \
+-  third_party/serf/libopenssl.a \
+   third_party/serf/libserf.a \
+-  third_party/zlib/libzlib.a \
+   url/liburl_lib.a
+
+ # The 'gclient' build flow uses 'xcodebuild' on Mac and 'make' on Linux.

--- a/patches/libpng_cflags.patch
+++ b/patches/libpng_cflags.patch
@@ -1,0 +1,12 @@
+--- a/src/third_party/libpng/libpng.gyp
++++ b/src/third_party/libpng/libpng.gyp
+@@ -111,9 +111,6 @@
+               '<!(<(pkg-config) --atleast-version=1.4.0 libpng; echo $?)'
+           },
+           'direct_dependent_settings': {
+-            'cflags': [
+-              '<!@(<(pkg-config) --cflags libpng)',
+-            ],
+             'defines+': [
+               'USE_SYSTEM_LIBPNG',
+               'DBG=<(png_free_me_suported_define_in_libpng)',

--- a/patches/pthread_nonrecursive_np.patch
+++ b/patches/pthread_nonrecursive_np.patch
@@ -1,0 +1,11 @@
+--- a/src/pagespeed/kernel/thread/pthread_rw_lock.cc
++++ b/src/pagespeed/kernel/thread/pthread_rw_lock.cc
+@@ -31,7 +31,7 @@
+   //
+   // Other OS's (FreeBSD, Darwin, OpenSolaris) documentation suggests
+   // that they prefer writers by default.
+-#ifdef linux
++#if defined(linux) && defined(__GLIBC__)
+   pthread_rwlockattr_setkind_np(&attr_,
+                                 PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
+ #endif

--- a/patches/rename_c_symbols.patch
+++ b/patches/rename_c_symbols.patch
@@ -1,0 +1,13 @@
+--- a/src/pagespeed/automatic/rename_c_symbols.sh
++++ b/src/pagespeed/automatic/rename_c_symbols.sh
+@@ -24,8 +24,8 @@
+ set -e  # exit script if any command returns an error
+ set -u  # exit the script if any variable is uninitialized
+
+-IN=$(readlink -f $1)
+-OUT=$(readlink -f $2)
++IN=$1
++OUT=$2
+
+ # Get a list of defined non-C++ symbols that are global and not weak.
+ # _Z is used at start of C++-mangled symbol names.

--- a/patches/stack_trace_posix.patch
+++ b/patches/stack_trace_posix.patch
@@ -1,0 +1,64 @@
+--- a/src/third_party/chromium/src/base/debug/stack_trace_posix.cc
++++ b/src/third_party/chromium/src/base/debug/stack_trace_posix.cc
+@@ -5,7 +5,9 @@
+ #include "base/debug/stack_trace.h"
+
+ #include <errno.h>
++#if defined(HAVE_BACKTRACE)
+ #include <execinfo.h>
++#endif
+ #include <fcntl.h>
+ #include <signal.h>
+ #include <stdio.h>
+@@ -64,7 +66,7 @@
+   // Note: code in this function is NOT async-signal safe (std::string uses
+   // malloc internally).
+
+-#if defined(__GLIBCXX__)
++#if defined(__GLIBCXX__) && defined(HAVE_BACKTRACE)
+
+   std::string::size_type search_from = 0;
+   while (search_from < text->size()) {
+@@ -145,7 +147,7 @@
+
+     handler->HandleOutput("\n");
+   }
+-#else
++#elif defined(HAVE_BACKTRACE)
+   bool printed = false;
+
+   // Below part is async-signal unsafe (uses malloc), so execute it only
+@@ -469,23 +471,31 @@
+ StackTrace::StackTrace() {
+   // NOTE: This code MUST be async-signal safe (it's used by in-process
+   // stack dumping signal handler). NO malloc or stdio is allowed here.
+-
++#if defined(HAVE_BACKTRACE)
+   // Though the backtrace API man page does not list any possible negative
+   // return values, we take no chance.
+   count_ = std::max(backtrace(trace_, arraysize(trace_)), 0);
++#else
++  count_ = 0;
++#endif
+ }
+
+ void StackTrace::Print() const {
+   // NOTE: This code MUST be async-signal safe (it's used by in-process
+   // stack dumping signal handler). NO malloc or stdio is allowed here.
+-
++#if defined(HAVE_BACKTRACE)
+   PrintBacktraceOutputHandler handler;
+   ProcessBacktrace(trace_, count_, &handler);
++#endif
+ }
+
+ void StackTrace::OutputToStream(std::ostream* os) const {
++#if !defined(HAVE_BACKTRACE)
++(*os) << "(stack trace not supported)\n";
++#else
+   StreamBacktraceOutputHandler handler(os);
+   ProcessBacktrace(trace_, count_, &handler);
++#endif
+ }
+
+ namespace internal {


### PR DESCRIPTION
Contains following components to support alpine 3.4:
 - Dockerfile
 - Custom built beta release tarball of mod-pagespeed (includes the upgraded GRPC version 1.4.5)
 - Patches for alpine support
 - README.md file 